### PR TITLE
fix mobile background for newsroom

### DIFF
--- a/scss/pages/_home.scss
+++ b/scss/pages/_home.scss
@@ -423,9 +423,6 @@ aside#HomepageSidebar {
         padding-top: 15px;
         padding-bottom: 30px;
     }
-    @media (max-width:$screen-phone) {
-        background-color: $White;
-    }
     .toparticle {
         display: block;
         clear: both;


### PR DESCRIPTION
Grey background colour was missing for the newsroom section at mobile size displays