### PR TITLE
feat: remove padding 0 from sidebar causing layout shift

### DIFF
--- a/scss/pages/_microsite.scss
+++ b/scss/pages/_microsite.scss
@@ -835,8 +835,7 @@ aside#sideBar .vcm-sideMenu
         }
         .vcm aside#sideBar
         {
-            padding:0;
-        
+            /* padding:0; */
         }
 }
 


### PR DESCRIPTION
Remove the `padding: 0` rule from the sidebar causing a big layout shift and huge white-space at the bottom of certain pages.